### PR TITLE
feat: add Subresource Integrity support

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/sri.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/sri.spec.ts
@@ -1,0 +1,146 @@
+import { createHash } from 'node:crypto'
+import type { OutputAsset, OutputBundle, OutputChunk } from 'rollup'
+import { describe, expect, it } from 'vitest'
+
+import { sriPlugin } from '../../plugins/sri'
+import type { ResolvedConfig } from '../../config'
+
+function integrity(
+  source: string | Uint8Array,
+  algorithm: 'sha256' | 'sha384' | 'sha512',
+): string {
+  const hash = createHash(algorithm)
+  hash.update(typeof source === 'string' ? source : Buffer.from(source))
+  return `${algorithm}-${hash.digest('base64')}`
+}
+
+describe('sri plugin', () => {
+  it('injects integrity, crossorigin and runtime', () => {
+    const config = {
+      base: '/',
+      build: { sri: { crossorigin: 'anonymous' } },
+    } as unknown as ResolvedConfig
+
+    const plugin = sriPlugin(config)
+
+    const js = `console.log('hi');import('./dynamic.js')`
+    const css = new TextEncoder().encode('body{color:red}')
+    const dyn = `console.log('dyn')`
+
+    const bundle: OutputBundle = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head></head><body><script src="/main.js"></script><link rel="stylesheet" href="/style.css"></body></html>',
+      } as OutputAsset,
+      'main.js': {
+        type: 'chunk',
+        fileName: 'main.js',
+        code: js,
+        dynamicImports: ['dynamic.js'],
+        isEntry: true,
+      } as unknown as OutputChunk,
+      'style.css': {
+        type: 'asset',
+        source: css,
+      } as OutputAsset,
+      'dynamic.js': {
+        type: 'chunk',
+        fileName: 'dynamic.js',
+        code: dyn,
+        dynamicImports: [],
+        isEntry: false,
+      } as unknown as OutputChunk,
+    }
+
+    ;(plugin.generateBundle as any)?.({}, bundle)
+
+    const jsHash = integrity(js, 'sha384')
+    const cssHash = integrity(css, 'sha384')
+    const dynHash = integrity(dyn, 'sha384')
+
+    const html = bundle['index.html'] as OutputAsset
+    expect(html.source as string).toContain(
+      `<script src="/main.js" integrity="${jsHash}" crossorigin="anonymous"></script>`,
+    )
+    expect(html.source as string).toContain(
+      `<link rel="stylesheet" href="/style.css" integrity="${cssHash}" crossorigin="anonymous">`,
+    )
+    expect(html.source as string).toContain(
+      `<link rel="modulepreload" href="/dynamic.js" integrity="${dynHash}" crossorigin="anonymous">`,
+    )
+
+    const rendered = (plugin.renderChunk as any)?.(js, {
+      isEntry: true,
+      fileName: 'main.js',
+    })
+    expect(rendered?.code).toContain('installSriRuntime')
+  })
+
+  it('respects base and disabled options', () => {
+    const config = {
+      base: '/foo/',
+      build: {
+        sri: {
+          algorithm: 'sha256',
+          crossorigin: 'use-credentials',
+          preloadDynamicImports: false,
+          runtime: false,
+        },
+      },
+    } as unknown as ResolvedConfig
+
+    const plugin = sriPlugin(config)
+
+    const js = `console.log('base');import('./dynamic.js')`
+    const css = 'body{color:blue}'
+    const dyn = `console.log('dyn')`
+
+    const bundle: OutputBundle = {
+      'index.html': {
+        type: 'asset',
+        source:
+          '<html><head></head><body><script src="/foo/main.js"></script><link rel="stylesheet" href="/foo/style.css"></body></html>',
+      } as OutputAsset,
+      'main.js': {
+        type: 'chunk',
+        fileName: 'main.js',
+        code: js,
+        dynamicImports: ['dynamic.js'],
+        isEntry: true,
+      } as unknown as OutputChunk,
+      'style.css': {
+        type: 'asset',
+        source: css,
+      } as OutputAsset,
+      'dynamic.js': {
+        type: 'chunk',
+        fileName: 'dynamic.js',
+        code: dyn,
+        dynamicImports: [],
+        isEntry: false,
+      } as unknown as OutputChunk,
+    }
+
+    ;(plugin.generateBundle as any)?.({}, bundle)
+
+    const jsHash = integrity(js, 'sha256')
+    const cssHash = integrity(css, 'sha256')
+
+    const html = bundle['index.html'] as OutputAsset
+    expect(html.source as string).toContain(
+      `<script src="/foo/main.js" integrity="${jsHash}" crossorigin="use-credentials"></script>`,
+    )
+    expect(html.source as string).toContain(
+      `<link rel="stylesheet" href="/foo/style.css" integrity="${cssHash}" crossorigin="use-credentials">`,
+    )
+    expect(html.source as string).not.toContain('modulepreload')
+
+    const rendered = (plugin.renderChunk as any)?.(js, {
+      isEntry: true,
+      fileName: 'main.js',
+    })
+    expect(rendered).toBeNull()
+  })
+})
+

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -58,6 +58,7 @@ import { dataURIPlugin } from './plugins/dataUri'
 import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { ssrManifestPlugin } from './ssr/ssrManifestPlugin'
 import { buildLoadFallbackPlugin } from './plugins/loadFallback'
+import { sriPlugin } from './plugins/sri'
 import { findNearestMainPackageData, findNearestPackageData } from './packages'
 import type { PackageCache } from './packages'
 import {
@@ -81,6 +82,17 @@ import {
 } from './deprecations'
 import { prepareOutDirPlugin } from './plugins/prepareOutDir'
 import type { Environment } from './environment'
+
+export interface BuildSriOptions {
+  /** Hash algorithm used for integrity calculation. Defaults to sha384 */
+  algorithm?: 'sha256' | 'sha384' | 'sha512'
+  /** Value for the crossorigin attribute on generated tags */
+  crossorigin?: 'anonymous' | 'use-credentials'
+  /** Whether to add modulepreload links for dynamic imports. Default true */
+  preloadDynamicImports?: boolean
+  /** Whether to inject a runtime to patch dynamic links/scripts. Default true */
+  runtime?: boolean
+}
 
 export interface BuildEnvironmentOptions {
   /**
@@ -276,6 +288,12 @@ export interface BuildEnvironmentOptions {
    */
   watch?: WatcherOptions | null
   /**
+   * Generate Subresource Integrity hashes for built assets.
+   * Set to an object to enable.
+   * @default false
+   */
+  sri?: false | BuildSriOptions
+  /**
    * create the Build Environment instance
    */
   createEnvironment?: (
@@ -389,6 +407,7 @@ export const buildEnvironmentOptionsDefaults = Object.freeze({
   reportCompressedSize: true,
   chunkSizeWarningLimit: 500,
   watch: null,
+  sri: false,
   // createEnvironment
 })
 
@@ -491,6 +510,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
       buildImportAnalysisPlugin(config),
       buildEsbuildPlugin(),
       terserPlugin(config),
+      ...(config.build.sri ? [sriPlugin(config)] : []),
       ...(!config.isWorker
         ? [manifestPlugin(), ssrManifestPlugin(), buildReporterPlugin(config)]
         : []),

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -123,6 +123,7 @@ export type {
   BuilderOptions,
   BuildOptions,
   BuildEnvironmentOptions,
+  BuildSriOptions,
   LibraryOptions,
   LibraryFormats,
   RenderBuiltAssetUrl,

--- a/packages/vite/src/node/plugins/sri.ts
+++ b/packages/vite/src/node/plugins/sri.ts
@@ -3,17 +3,7 @@ import { parse, serialize } from 'parse5'
 import type { OutputBundle } from 'rollup'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
-
-export interface BuildSriOptions {
-  /** Hashing algorithm to use. Defaults to sha384 */
-  algorithm?: 'sha256' | 'sha384' | 'sha512'
-  /** Value for the crossorigin attribute on generated tags */
-  crossorigin?: 'anonymous' | 'use-credentials'
-  /** Inject modulepreload links for dynamically imported chunks. Default true */
-  preloadDynamicImports?: boolean
-  /** Inject a small runtime to set integrity on dynamic links/scripts. Default true */
-  runtime?: boolean
-}
+import type { BuildSriOptions } from '../build'
 
 export function sriPlugin(config: ResolvedConfig): Plugin {
   const options = (config.build.sri || {}) as BuildSriOptions

--- a/packages/vite/src/node/plugins/sri.ts
+++ b/packages/vite/src/node/plugins/sri.ts
@@ -1,0 +1,248 @@
+import { createHash } from 'node:crypto'
+import { parse, serialize } from 'parse5'
+import type { OutputBundle } from 'rollup'
+import type { Plugin } from '../plugin'
+import type { ResolvedConfig } from '../config'
+
+export interface BuildSriOptions {
+  /** Hashing algorithm to use. Defaults to sha384 */
+  algorithm?: 'sha256' | 'sha384' | 'sha512'
+  /** Value for the crossorigin attribute on generated tags */
+  crossorigin?: 'anonymous' | 'use-credentials'
+  /** Inject modulepreload links for dynamically imported chunks. Default true */
+  preloadDynamicImports?: boolean
+  /** Inject a small runtime to set integrity on dynamic links/scripts. Default true */
+  runtime?: boolean
+}
+
+export function sriPlugin(config: ResolvedConfig): Plugin {
+  const options = (config.build.sri || {}) as BuildSriOptions
+  const algorithm = options.algorithm || 'sha384'
+  const crossorigin = options.crossorigin
+  const preloadDynamic = options.preloadDynamicImports !== false
+  const runtime = options.runtime !== false
+
+  let base = config.base || '/'
+  if (!base.endsWith('/')) base += '/'
+
+  const sriMap = new Map<string, string>()
+  const dynamicImports = new Set<string>()
+
+  return {
+    name: 'vite:sri',
+    apply: 'build',
+    enforce: 'post',
+
+    generateBundle(_: unknown, bundle: OutputBundle) {
+      for (const [fileName, out] of Object.entries(bundle)) {
+        if (out.type === 'asset') {
+          if (/\.(css|js|mjs)$/i.test(fileName)) {
+            const source = out.source as string | Uint8Array
+            sriMap.set('/' + fileName, createIntegrity(source, algorithm))
+          }
+        } else if (out.type === 'chunk') {
+          if (/\.(css|js|mjs)$/i.test(fileName)) {
+            sriMap.set('/' + fileName, createIntegrity(out.code, algorithm))
+          }
+          if (preloadDynamic && out.dynamicImports) {
+            for (const dep of out.dynamicImports) {
+              const imported = bundle[dep]
+              if (imported && imported.type === 'chunk') {
+                dynamicImports.add(imported.fileName)
+              } else {
+                dynamicImports.add(dep)
+              }
+            }
+          }
+        }
+      }
+
+      for (const [fileName, out] of Object.entries(bundle)) {
+        if (out.type === 'asset' && fileName.endsWith('.html')) {
+          const html = typeof out.source === 'string' ? out.source : String(out.source)
+          out.source = processHtml(
+            html,
+            sriMap,
+            dynamicImports,
+            base,
+            crossorigin,
+            preloadDynamic,
+          )
+        }
+      }
+    },
+
+    renderChunk(code, chunk) {
+      if (!runtime || !chunk.isEntry) return null
+      if (sriMap.size === 0) return null
+      const mapObject = Object.fromEntries(sriMap)
+      const serialized = JSON.stringify(mapObject)
+      const cors = crossorigin ? JSON.stringify(crossorigin) : 'false'
+      const injected = `\n(${installSriRuntime.toString()})(${serialized}, { crossorigin: ${cors} });\n`
+      return { code: injected + code, map: null }
+    },
+  }
+}
+
+function createIntegrity(
+  source: string | Uint8Array,
+  algorithm: 'sha256' | 'sha384' | 'sha512',
+): string {
+  const hash = createHash(algorithm)
+  hash.update(typeof source === 'string' ? source : Buffer.from(source))
+  return `${algorithm}-${hash.digest('base64')}`
+}
+
+function processHtml(
+  html: string,
+  sriMap: Map<string, string>,
+  dynamicImports: Set<string>,
+  base: string,
+  crossorigin: string | undefined,
+  preloadDynamic: boolean,
+): string {
+  const document = parse(html)
+  const head = findElement(document, 'head')
+  const existingPreloads = new Set<string>()
+
+  const lookup = (url: string): string | undefined => {
+    try {
+      const u = new URL(url, 'http://example.com')
+      let p = u.pathname
+      if (base !== '/' && p.startsWith(base)) {
+        p = '/' + p.slice(base.length)
+      }
+      return sriMap.get(p)
+    } catch {
+      return undefined
+    }
+  }
+
+  const visit = (node: any): void => {
+    if (node.tagName === 'script') {
+      const src = getAttr(node, 'src')
+      if (src) {
+        const integrity = lookup(src)
+        if (integrity) {
+          setAttr(node, 'integrity', integrity)
+          if (crossorigin) setAttr(node, 'crossorigin', crossorigin)
+        }
+      }
+    } else if (node.tagName === 'link') {
+      const rel = getAttr(node, 'rel')
+      const href = getAttr(node, 'href')
+      if (href) {
+        if (rel === 'modulepreload') existingPreloads.add(href)
+        if (
+          rel === 'stylesheet' ||
+          rel === 'modulepreload' ||
+          (rel === 'preload' && ['script', 'style', 'font'].includes(getAttr(node, 'as') || ''))
+        ) {
+          const integrity = lookup(href)
+          if (integrity) {
+            setAttr(node, 'integrity', integrity)
+            if (crossorigin) setAttr(node, 'crossorigin', crossorigin)
+          }
+        }
+      }
+    }
+    if (node.childNodes) node.childNodes.forEach(visit)
+  }
+  visit(document)
+
+  if (preloadDynamic && head) {
+    for (const file of dynamicImports) {
+      const href = base + file
+      if (existingPreloads.has(href)) continue
+      const integrity = sriMap.get('/' + file)
+      if (!integrity) continue
+      const attrs: any[] = [
+        { name: 'rel', value: 'modulepreload' },
+        { name: 'href', value: href },
+        { name: 'integrity', value: integrity },
+      ]
+      if (crossorigin) attrs.push({ name: 'crossorigin', value: crossorigin })
+      const linkNode: any = {
+        nodeName: 'link',
+        tagName: 'link',
+        attrs,
+        namespaceURI: 'http://www.w3.org/1999/xhtml',
+        childNodes: [],
+        parentNode: head,
+      }
+      head.childNodes.unshift(linkNode)
+    }
+  }
+
+  return serialize(document)
+}
+
+function findElement(node: any, tag: string): any | null {
+  if (node.tagName === tag) return node
+  if (node.childNodes) {
+    for (const child of node.childNodes) {
+      const res = findElement(child, tag)
+      if (res) return res
+    }
+  }
+  return null
+}
+
+function getAttr(node: any, name: string): string | undefined {
+  const attr = node.attrs?.find((a: any) => a.name === name)
+  return attr?.value
+}
+
+function setAttr(node: any, name: string, value: string): void {
+  const attr = node.attrs?.find((a: any) => a.name === name)
+  if (attr) {
+    attr.value = value
+  } else {
+    node.attrs = node.attrs || []
+    node.attrs.push({ name, value })
+  }
+}
+
+function installSriRuntime(
+  sri: Record<string, string>,
+  opts?: { crossorigin?: false | 'anonymous' | 'use-credentials' },
+) {
+  try {
+    const cors =
+      opts && Object.prototype.hasOwnProperty.call(opts, 'crossorigin')
+        ? opts.crossorigin
+        : 'anonymous'
+    const lookup = (url: string): string | undefined => {
+      try {
+        const u = new URL(url, location.href)
+        return sri[u.pathname]
+      } catch {
+        return undefined
+      }
+    }
+    const apply = (el: any) => {
+      const url = el.tagName === 'LINK' ? el.href : el.src
+      const integrity = lookup(url)
+      if (integrity) {
+        if (!el.integrity) el.integrity = integrity
+        if (cors && !el.crossOrigin) el.crossOrigin = cors
+      }
+    }
+    const observer = new MutationObserver((records) => {
+      for (const r of records) {
+        for (const n of Array.from(r.addedNodes)) {
+          if ((n as any).tagName === 'SCRIPT' || (n as any).tagName === 'LINK') {
+            apply(n)
+          }
+        }
+      }
+    })
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    })
+  } catch {
+    // ignore
+  }
+}
+


### PR DESCRIPTION
## Summary
- add built-in plugin to generate Subresource Integrity hashes for JS and CSS assets
- allow enabling SRI via new `build.sri` option and export associated types

## Testing
- `pnpm --filter vite lint` *(fails: files ignored)*
- `pnpm --filter vite typecheck` *(fails: missing module declarations)*
- `pnpm test-unit` *(fails: vitest command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cda0960fc8322980cf06401675024